### PR TITLE
deassert CS later to meet CFA hold time specification

### DIFF
--- a/pld/extcompactflash.pld
+++ b/pld/extcompactflash.pld
@@ -25,7 +25,7 @@ Pin 17 = !RD_O;
 Pin 18 = !WR_O;
 Pin 16 = !RD_TMP;
 Pin 15 = !WR_TMP;
-Pin 19 = !CS; // Combinatorial CS
+Pin 19 = !CS2; // Combinatorial CS
 
 /** Outputs **/
 Pin 14 = !CF_CS; // Delayed CS, intermediate
@@ -34,6 +34,8 @@ Pin 14 = !CF_CS; // Delayed CS, intermediate
 CS = IORQ & !ADDR7 & ADDR6 & ADDR5 & ADDR4;
 
 CF_CS.d = CS;
+
+CS2 = CS # CF_CS;
 
 RD_O = CF_CS & RD & CS;
 WR_O = CF_CS & WR & CS;


### PR DESCRIPTION
Combines the immediate chip select signal (CS) with the existing latched version (CF_CS) to generate the final chip select for the card.

This introduces a ~40ns hold time after -RD/-WR deassert, ensuring reliable operation with all tested CFA-compliant cards, while maintaining compatibility with cards that identify as IDE.